### PR TITLE
add python 3.4/3.5 environment in build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.12
+    - pyenv global 2.7.12 3.4.4 3.5.2
 
 test:
   pre:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27
+envlist = py27,py34,py35
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Looks like no code change required. both 3.4 and 3.5 build passed.