### PR TITLE
fix test warnings and add check_estimator test

### DIFF
--- a/bnp/online_hdp.py
+++ b/bnp/online_hdp.py
@@ -378,7 +378,6 @@ class HierarchicalDirichletProcess(BaseEstimator, TransformerMixin):
         self.n_jobs = int(n_jobs)
         self.verbose = int(verbose)
         self.random_state = random_state
-        self.initialized_ = False
 
     def _check_params(self):
         """Check model parameters."""
@@ -433,6 +432,7 @@ class HierarchicalDirichletProcess(BaseEstimator, TransformerMixin):
         """Initialize latent variables."""
 
         self.random_state_ = check_random_state(self.random_state)
+        self.n_iter_ = 0
 
         # initialize global variational variables
         # follow reference [3]
@@ -451,7 +451,6 @@ class HierarchicalDirichletProcess(BaseEstimator, TransformerMixin):
                                   np.arange(self.n_topic_truncate-1, 0, -1)])
         self.elog_v_stick_ = log_stick_expectation(self.v_stick_)
         self.sstats_v_stick_ = np.zeros(self.n_topic_truncate)
-        self.initialized_  = True
 
     def _init_min_batch_parameters(self):
         self.n_mini_batch_iter_ = 1
@@ -641,6 +640,7 @@ class HierarchicalDirichletProcess(BaseEstimator, TransformerMixin):
                     bound = self.score(X)
                     if self.verbose:
                         print('iteration: %d, ELOB: %.4f' % (i + 1, bound))
+                self.n_iter_ += 1
         return self
 
     def transform(self, X):

--- a/bnp/tests/test_extmath.py
+++ b/bnp/tests/test_extmath.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from numpy.random import RandomState
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.extmath import logsumexp
+from scipy.misc import logsumexp
 
 from bnp.utils.extmath import (row_log_normalize_exp,
                                mean_change_2d, beta_param_update)

--- a/bnp/tests/test_hdp.py
+++ b/bnp/tests/test_hdp.py
@@ -4,6 +4,7 @@ from sklearn.externals.six.moves import xrange
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.testing import (assert_almost_equal, assert_raises_regexp,
                                    assert_equal, assert_true, assert_greater_equal)
+from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils import shuffle
 
 from bnp.online_hdp import HierarchicalDirichletProcess
@@ -26,6 +27,11 @@ def _hdp_topic_check(hdp_model, n_topics, words_per_topic,
         assert_equal(max_idx - min_idx, words_per_topic - 1)
         topic_covers[int(min_idx / words_per_topic)] = 1
     assert_true((topic_covers > 0.).all())
+
+
+def test_estimator():
+    """Test HDP estimator"""
+    return check_estimator(HierarchicalDirichletProcess)
 
 
 def test_hdp_fit_transform():


### PR DESCRIPTION
1. use `scipy.misc.logsumexp` replace `sklearn.utils.extmath.logsumexp`

2. add `check_estimator` test and fix related errors.